### PR TITLE
Fix book-author relationship

### DIFF
--- a/db/migrate/20151113173639_fix_book_author_relation.rb
+++ b/db/migrate/20151113173639_fix_book_author_relation.rb
@@ -1,0 +1,8 @@
+class FixBookAuthorRelation < ActiveRecord::Migration
+  def change
+    remove_column :authors, :books_id, :integer
+    remove_column :authors, :author_id, :integer
+    add_reference :books, :author, index: true,
+                                   foreign_key: { on_delete: :cascade }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110031941) do
+ActiveRecord::Schema.define(version: 20151113173639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 20151110031941) do
     t.datetime "updated_at",      null: false
     t.integer  "author_id"
   end
+
+  add_index "books", ["author_id"], name: "index_books_on_author_id", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false


### PR DESCRIPTION
The relationship was setup incorrectly at the db level and the master
branch was failing.

The authors table had `books_id` and `authors_id` columns, but for a
`Book` to belong to an author, the books table should have an `author_id`.

Strangely, the master branch has the [correct](https://github.com/ajkamel/cover/blob/master/db/schema.rb#L19) [schema](https://github.com/ajkamel/cover/blob/master/db/schema.rb#L42), but an issue with [a migration](https://github.com/ajkamel/cover/blob/master/db/migrate/20151109224135_create_authors.rb#L6). I wonder if the issue came up because we discussed combining migrations in our code review the other day. It's curious that git only shows a timestamp diff on `schema.rb`, so I'm guessing the correct schema was checked in, but the migration was edited and rebased into the commit.

To replicate the issue, checkout master locally and `rake db:drop db:create db:migrate` and then run the specs, there should be several failing because of the book-author relationship. Or maybe it's just me?