### PR TITLE
adds sort by average review

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,6 +9,7 @@ class ReviewsController < ApplicationController
   def create
     @review = @book.reviews.build(review_params)
     if @review.save
+      RatingUpdatingJob.perform_later(@book)
       redirect_to book_path(@book), notice: 'Thanks for adding your review'
     else
       render :new

--- a/app/jobs/rating_updating_job.rb
+++ b/app/jobs/rating_updating_job.rb
@@ -1,0 +1,7 @@
+class RatingUpdatingJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(book)
+    book.update_avg_rating
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -20,4 +20,8 @@ class Book < ActiveRecord::Base
   def to_param
     "#{id}-#{title.parameterize}"
   end
+
+  def update_avg_rating
+    update(average_rating: reviews.average(:rating))
+  end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,4 +6,12 @@ class Review < ActiveRecord::Base
   validates :rating, inclusion: 1..5
 
   delegate :email, to: :user, prefix: true
+
+  after_commit :update_avg_rating
+
+  private
+
+  def update_avg_rating
+    RatingUpdatingJob.perform_later(book)
+  end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -8,6 +8,7 @@
       <td>Title</td>
       <td>Cover</td>
       <td>Genre</td>
+      <td><%= sortable 'average_rating', 'Average Rating' %></td>
       <td><%= sortable 'published_on', 'Published Date' %></td>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
       <td><%= link_to book.title, book_path(book) %></td>
       <td><%= link_to book_cover(book), book_path(book)  %></td>
       <td><%= book.genre_name  %></td>
+      <td><%= book.average_rating %></td>
       <td><%= book.published_on  %></td>
     <% end %>
   </tbody>

--- a/db/migrate/20151116015128_add_average_rating_to_books.rb
+++ b/db/migrate/20151116015128_add_average_rating_to_books.rb
@@ -1,0 +1,6 @@
+class AddAverageRatingToBooks < ActiveRecord::Migration
+  def change
+    add_column :books, :average_rating, :integer, default: 0
+    add_index :books, :average_rating
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151115142523) do
+ActiveRecord::Schema.define(version: 20151116015128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,17 +34,19 @@ ActiveRecord::Schema.define(version: 20151115142523) do
   add_index "book_lists", ["list_id"], name: "index_book_lists_on_list_id", using: :btree
 
   create_table "books", force: :cascade do |t|
-    t.string   "title",           null: false
+    t.string   "title",                       null: false
     t.text     "description"
     t.string   "cover_image_url"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.integer  "author_id",       null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "author_id",                   null: false
     t.integer  "genre_id"
     t.date     "published_on"
+    t.integer  "average_rating",  default: 0
   end
 
   add_index "books", ["author_id"], name: "index_books_on_author_id", using: :btree
+  add_index "books", ["average_rating"], name: "index_books_on_average_rating", using: :btree
   add_index "books", ["genre_id"], name: "index_books_on_genre_id", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/features/user_views_all_books_spec.rb
+++ b/spec/features/user_views_all_books_spec.rb
@@ -40,6 +40,16 @@ feature 'User views all books' do
     expect('older_book').to appear_before 'newer_book'
   end
 
+  scenario 'sort by average review' do
+    create(:book, title: 'higher_rated_book', average_rating: 4)
+    create(:book, title: 'lower_rated_book', average_rating: 3)
+
+    visit books_path
+    click_on('Average Rating')
+
+    expect('lower_rated_book').to appear_before 'higher_rated_book'
+  end
+
   def have_pagination
     have_css('.pagination')
   end

--- a/spec/jobs/rating_updating_job_spec.rb
+++ b/spec/jobs/rating_updating_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe RatingUpdatingJob, type: :job do
+  describe '#perform' do
+    it 'calls book.update_avg_rating' do
+      book = create(:book)
+      allow(book).to receive(:update_avg_rating)
+
+      RatingUpdatingJob.perform_now(book)
+
+      expect(book).to have_received(:update_avg_rating)
+    end
+  end
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe Book, type: :model do
       expect(book.reviewed_by?(user_without_review)).to eq false
     end
   end
+
+  describe '#update_avg_rating' do
+    it 'updates the book rating' do
+      book = create(:book)
+      create(:review, rating: 3, book: book)
+      create(:review, rating: 5, book: book)
+
+      book.update_avg_rating
+
+      expect(book.average_rating).to eq 4
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/XctSVpOz/21-books-sortable-by-date-and-avg-review

This commit adds a sort by average rating to the books index.  We also
added a background job to catch for the case of a large amount of
reviews, and we wouldn't want to delay the render of the page while that
calculates.  This commit also tests the background job and the
controller that calls the background job to see that the method
update_avg_rating is called.